### PR TITLE
fix for incorrect beautification

### DIFF
--- a/frozen_cookies.js
+++ b/frozen_cookies.js
@@ -144,7 +144,12 @@ function fcBeautify (value) {
         notationValue = notation[base];
       }
     }
-    value = Math.round(value * 1000) / 1000.0;
+    if (Math.round(value * 1000) >= 1000000) {
+      notationValue = notation[base + 1];
+      value = Math.round(value * 1000) / 1000000.0;
+    } else {
+      value = Math.round(value * 1000) / 1000.0;
+    }
   }
   if (!Number.isFinite(value)) {
     return 'Infinity';


### PR DESCRIPTION
Fix: Beautifying the value of 999,999,999,999,999 becomes 1,000 trillion when it should be 1 quadrillion

This can be seen when going to purchase cookies such as Loreols, Caramoas and Sagalongs.

The problem is that it calculates the notation as in the trillions (since it isn't in the quadrillions yet) initially and then it rounds the number up to 1000 and adds it onto the trillion

This is untested but it should work, so make sure it works before pushing this change
