### PR TITLE
Use a different method for auto-clicking

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -1021,7 +1021,9 @@ function FCStart() {
 //  }
   
   if (FrozenCookies.autoClick && FrozenCookies.cookieClickSpeed) {
-    FrozenCookies.autoclickBot = setInterval(Game.ClickCookie, 1000 / FrozenCookies.cookieClickSpeed);
+    FrozenCookies.autoclickBot = setInterval(function () {
+		document.getElementByID('bigCookie').click();
+	}, 1000 / FrozenCookies.cookieClickSpeed);
   }
   
   if (FrozenCookies.autoFrenzy && FrozenCookies.frenzyClickSpeed) {


### PR DESCRIPTION
Clicking the actual element has the benefit of also causing a click
event on the game canvas, so you can use it to kill wrinklers faster.
