### PR TITLE
Beautify upgrades' and achievements' numbers

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -66,6 +66,7 @@ function setOverrides() {
   // Remove the following when turning on tooltop code
   Game.RebuildStore();
   Game.RebuildUpgrades();
+  beautifyUpgradesAndAchievements();
   // Replace Game.Popup references with event logging
   eval("Game.goldenCookie.click = " + Game.goldenCookie.click.toString().replace(/Game\.Popup\((.+)\)\;/g, 'logEvent("GC", $1, true);'));
   eval("Game.UpdateWrinklers = " + Game.UpdateWrinklers.toString().replace(/Game\.Popup\((.+)\)\;/g, 'logEvent("Wrinkler", $1, true);'));
@@ -126,6 +127,23 @@ function fcBeautify (value) {
     var output = value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + notationValue;
     return negative ? '-' + output : output;
   }
+}
+
+// Runs numbers in upgrades and achievements through our beautify function
+function beautifyUpgradesAndAchievements() {
+  function beautifyFn(str) {
+    return Game.Beautify(parseInt(str.replace(/,/, ''), 10));
+  }
+
+  var numre = /\d\d?\d?(?:,\d\d\d)*/;
+  Game.AchievementsById.forEach(function (ach) {
+    ach.desc = ach.desc.replace(numre, beautifyFn);
+  });
+
+  // These might not have any numbers in them, but just in case...
+  Game.UpgradesById.forEach(function (upg) {
+    upg.desc = upg.desc.replace(numre, beautifyFn);
+  });
 }
 
 function timeDisplay(seconds) {


### PR DESCRIPTION
Fixes #47

Fixes things like this one:

{
  name: "Let's never bake again",
  desc: "Bake <b>1,000,000,000,000</b> cookies per second."
}

I don't think anything else needs running through this, and I don't
think we need to do it more than once per script run, but I can add them
if that's necessary.
