### PR TITLE
Update fc_userscript_loader.user.js

### DIFF
--- a/fc_userscript_loader.user.js
+++ b/fc_userscript_loader.user.js
@@ -21,5 +21,5 @@ function LoadFrozenCookies() {
   document.head.appendChild(js);
 }
 // It's not the best way but Chrome doesn't work with addEventListener... :(
-// Delay load by 2 seconds to allow the site to load itself first.)
-window.setTimeout(LoadFrozenCookies, 2000);
+// Delay load by 5 seconds to allow the site to load itself first.)
+window.setTimeout(LoadFrozenCookies, 5000);


### PR DESCRIPTION
2 seconds may not be enough on older machines; giving it 5 seconds to load instead may be a better trade-off between the user waiting for Frozen Cookies to load and Frozen Cookies waiting for Cookie Clicker to load.
