### PR TITLE
Additional number formatting for much larger numbers

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -154,7 +154,7 @@ var numberFormatters = [
     ' septillion',
     ' octillion',
     ' nonillion',
-    ' decillion',
+    ' decillion'
   ]),
 
   formatEveryThirdPower([
@@ -168,7 +168,7 @@ var numberFormatters = [
     ' Sp',
     ' Oc',
     ' No',
-    ' De',
+    ' De'
   ]),
 
   formatEveryThirdPower([


### PR DESCRIPTION
The existing number formatting for names and initials stop at "septillion", but many players (including nearly anyone with 1 million or more HC) regularly deals in numbers orders of magnitude larger than this. It's a trivial matter to handle larger numbers than this in these two formatters, simply add new names.

I would have also updated the SI unit abbreviations, but I can't find a reliable source for what they should be, and the few random sources I can find do not all agree.
