### PR TITLE
add logic to calculate efficient reset

### DIFF
--- a/fc_button.js
+++ b/fc_button.js
@@ -330,7 +330,7 @@ function FCMenu() {
       return Game.oldUpdateMenu();
     }
     var currentCookies, maxCookies, isTarget, isMax, targetTxt, maxTxt,
-      currHC, resetHC, cps, baseChosen, frenzyChosen, clickStr, buildTable,
+      currHC, resetHC, gainedHC, cps, baseChosen, frenzyChosen, clickStr, buildTable,
       bankLucky, bankLuckyFrenzy, bankChain,
       menu = $('#menu').html('')
         .append($('<div>').addClass('section').html('Frozen Cookies v ' + FrozenCookies.branch + '.' + FrozenCookies.version)),
@@ -404,8 +404,11 @@ function FCMenu() {
     subsection.append($('<div>').addClass('title').html('Heavenly Chips Information'));
     currHC = Game.heavenlyChipsEarned;
     resetHC = Game.HowMuchPrestige(Game.cookiesReset + Game.cookiesEarned + wrinklerValue() + chocolateValue());
+    gainedHC = resetHC - currHC;
     subsection.append($('<div>').addClass('listing').html('<b>HC Now:</b> ' + Beautify(Game.heavenlyChipsEarned)));
+    subsection.append($('<div>').addClass('listing').html('<b>HC Gained By Reset:</b> ' + Beautify(gainedHC)));
     subsection.append($('<div>').addClass('listing').html('<b>HC After Reset:</b> ' + Beautify(resetHC)));
+    subsection.append($('<div>').addClass('listing').html('<b>HC Required Before Optimal Reset:</b> ' + Beautify(estimatedHCTillReset(gainedHC))));
     subsection.append($('<div>').addClass('listing').html('<b>Cookies to next HC:</b> ' + Beautify(nextHC(true))));
     subsection.append($('<div>').addClass('listing').html('<b>Estimated time to next HC:</b> ' + nextHC()));
     if (currHC < resetHC) {

--- a/fc_main.js
+++ b/fc_main.js
@@ -480,6 +480,31 @@ function effectiveCps(delay, wrathValue, wrinklerCount) {
   return baseCps() * wrinkler + gcPs(cookieValue(delay, wrathValue, wrinklerCount)) + baseClickingCps(FrozenCookies.cookieClickSpeed * FrozenCookies.autoClick) + reindeerCps(wrathValue);
 }
 
+function estimatedHCTillReset(gainedHC) {
+	// Reset when E*T - C = (1/2)h^2
+	// Where:
+	// C = cookies baked (this game) divided by one trillion
+	// T = Session started this many seconds ago
+	// E = effective CPS
+	// h = number of heavenly chips you'd gain if you reset now
+
+	// Equivalently: number of heavenly chips to earn before you reset
+	// h = sqrt(2*E*T - 2C)
+
+	var C = Game.cookiesEarned / 1000000000000;
+	var E = effectiveCps() / 1000000000000;
+	var T = Date.now() - Game.startDate;
+
+	var total = 2*E*T - 2*C;
+
+	// Protect against sqrt of negative number
+	if (total < 0) {
+		return 0;
+	} else {
+		return Math.max(0, Math.ceil(Math.sqrt(total)) - gainedHC);
+	}
+}
+
 function frenzyProbability(wrathValue) {
   wrathValue = wrathValue != null ? wrathValue : Game.elderWrath;
   return cookieInfo.frenzy.odds[wrathValue];// + cookieInfo.frenzyRuin.odds[wrathValue] + cookieInfo.frenzyLucky.odds[wrathValue] + cookieInfo.frenzyClick.odds[wrathValue];


### PR DESCRIPTION
Based on the formula from Cookie Clicker's subreddit, we calculate the
number of heavenly chips we need to earn before resetting becomes more
efficient than not. This is done by the formula

E*T - C = 1/2 h^2

where:
E = current effective cookies per second divided by 1 trillion
T = seconds since session started
C = total cookies earned this session divided by 1 trillion
h = number of heavenly chips you will _gain_ on reset

equivalently, we can re-write this formula to find by as:

h = sqrt(2_E_T - C*2)

This tells us how many heavenly chips we need to earn by resetting in
order to be more efficient to reset. Then, we subtract from this the total
number of chips we've already acquired . Thus we can display how many
heavenly chips remain to earn before an efficient reset.

Possible future enhancements would be to tie resets into the "purchase"
equation and automatically reset. However, I was not that ambitious yet.

Signed-off-by: Jacob Keller jacob.keller@gmail.com

Conflicts:
    fc_button.js
