### PR TITLE
Get Frozen Cookies to load in 1.9 beta

### DIFF
--- a/cc_upgrade_prerequisites.js
+++ b/cc_upgrade_prerequisites.js
@@ -271,11 +271,11 @@ var upgradeJson = [
 
 var blacklist = [
   {
-    'upgrades': [],
+    'upgrades': [331],
     'buildings': []
   },
   {
-    'upgrades': [129,130,131,132,133],
+    'upgrades': [129,130,131,132,133,331],
     'buildings': []
   },
   {
@@ -283,11 +283,11 @@ var blacklist = [
     'buildings': []
   },
   {
-    'upgrades': [71, 72, 73, 74, 84, 85],
+    'upgrades': [71, 72, 73, 74, 84, 85, 331],
     'buildings': []
   },
   {
-    'upgrades': [],
+    'upgrades': [331],
     'buildings': true
   }
 ];

--- a/fc_main.js
+++ b/fc_main.js
@@ -349,7 +349,7 @@ document.addEventListener('keydown', function(event) {
       copyToClipboard(Game.WriteSave(true));
     }
     if (event.keyCode == 82) {
-      Game.Reset();
+      Game.Ascend();
     }
     if (event.keyCode == 83) {
       Game.WriteSave();

--- a/fc_main.js
+++ b/fc_main.js
@@ -1132,7 +1132,7 @@ function buildingToggle(building, achievements) {
     achievements.forEach(function(won, index){
       var achievement = Game.AchievementsById[index];
       achievement.won = won;
-      if (won && achievement.hide < 3) {
+      if (won && achievement.pool !== 'shadow') {
         Game.AchievementsOwned += 1;
       }
     });

--- a/fc_main.js
+++ b/fc_main.js
@@ -56,6 +56,7 @@ function setOverrides() {
   FrozenCookies.disabledPopups = true;
   FrozenCookies.trackedStats = [];
   FrozenCookies.lastGraphDraw = 0;
+  FrozenCookies.calculatedCpsByType = {};
   
   // Allow autoCookie to run
   FrozenCookies.processing = false;


### PR DESCRIPTION
This change gets the script to at least load. Additional functionality may be necessary for full 1.9 support.

Blacklist golden switch upgrade because it turns off golden cookies when on

Fix milk getting reset to 0

Update reset keyboard shortcut to use new ascension menu