### PR TITLE
Update and improve old userscript

### DIFF
--- a/fc_userscript_loader.user.js
+++ b/fc_userscript_loader.user.js
@@ -5,21 +5,21 @@
 // @author         shinji257
 // @homepage       https://github.com/Icehawk78/FrozenCookies
 // @include        http://orteil.dashnet.org/cookieclicker/
-// @updateURL      http://icehawk78.github.io/FrozenCookies/fc_userscript_loader.js
-// @downloadURL    http://icehawk78.github.io/FrozenCookies/fc_userscript_loader.js
+// @updateURL      https://rawgithub.com/Icehawk78/FrozenCookies/master/fc_userscript_loader.js
+// @downloadURL    https://rawgithub.com/Icehawk78/FrozenCookies/master/fc_userscript_loader.js
+// @run-at         document-start
 // ==/UserScript==
 
-// Dev:       https://raw.github.com/Icehawk78/FrozenCookies/development/
-// Master:    https://raw.github.com/Icehawk78/FrozenCookies/master/
+// Dev:       https://www.github.com/Icehawk78/FrozenCookies/development/
+// Master:    https://www.github.com/Icehawk78/FrozenCookies/master/
 // Github.io: http://icehawk78.github.io/FrozenCookies/
 
 function LoadFrozenCookies() {
   var js = document.createElement('script');
   js.setAttribute('type', 'text/javascript');
   js.setAttribute('id', 'frozenCookieScript');
-  js.setAttribute('src', 'https://raw.github.com/Icehawk78/FrozenCookies/master/frozen_cookies.js');
+  js.setAttribute('src', 'https://rawgithub.com/Icehawk78/FrozenCookies/master/frozen_cookies.js');
   document.head.appendChild(js);
 }
-// It's not the best way but Chrome doesn't work with addEventListener... :(
-// Delay load by 5 seconds to allow the site to load itself first.)
-window.setTimeout(LoadFrozenCookies, 5000);
+
+window.addEventListener("load", LoadFrozenCookies, false);


### PR DESCRIPTION
Here is an updated user script to replace the old one.  URLs are fixed as appropriate and it is now using an appropriate document listener so it doesn't waste time in loading.

* change setTimeout to addEventListener
* Use @run-at to get it to load at an appropriate timeframe so that the above change can actually work.  Seems to work consistently.  Tested in Chrome using Tampermonkey and Firefox using Greasemonkey.
* Fix a few url pointers.  Pointed downloadurl and updateurl to the rawgithub.com version of the url so that it gets the raw version and pointed the src setAttribute appropriately.  Due to strict checking in Tampermonker (at least) it is necessary since github's normal raw url sends as text/plain instead of text/javascript.  Seems rawgithub.com uses the expected doc type.
* Changed the commented dev/master urls to the main website instead of tha raw version since it is giving an invalid request error anyways.  Not sure what the intent was on those comments.