### PR TITLE
Default `App` undefined to prevent errors on web

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -148,6 +148,10 @@ function setOverrides(gameSaveData) {
   if (!blacklist[FrozenCookies.blacklist]) {
     FrozenCookies.blacklist = 0;
   }
+
+  // Set `App`, on older version of CC it's not set to anything, so default it to `undefined`
+  if (!window.App) window.App = undefined
+
   Beautify = fcBeautify;
   Game.sayTime = function (time, detail) {
     return timeDisplay(time / Game.fps);

--- a/fc_main.js
+++ b/fc_main.js
@@ -150,7 +150,7 @@ function setOverrides(gameSaveData) {
   }
 
   // Set `App`, on older version of CC it's not set to anything, so default it to `undefined`
-  if (!window.App) window.App = undefined
+  if (!window.App) window.App = undefined;
 
   Beautify = fcBeautify;
   Game.sayTime = function (time, detail) {


### PR DESCRIPTION
This fixes the `App` not-existance errors on non-Steam versions of Cookie Clicker.