### PR TITLE
Change auto-Godmazok to cursors and farms

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -2722,29 +2722,25 @@ function autoGodzamokAction() {
     // if Pantheon is here and autoGodzamok is set
     if (
       Game.hasGod("ruin") &&
-      (Game.Objects["Farm"].amount > 10 || Game.Objects["Mine"].amount > 10  || Game.Objects["Factory"].amount > 10)
+      (Game.Objects["Cursor"].amount > 10 || Game.Objects["Farm"].amount > 10)
     ) {
+      var countCursor = Game.Objects["Cursor"].amount - 1;
       var countFarm = Game.Objects["Farm"].amount - 1;
-      var countMine = Game.Objects["Mine"].amount - 1;
-      var countFactory = Game.Objects["Factory"].amount - 1;
 
-      //Automatically sell all farms, mines, and factories (except one) during Dragonflight and Click Frenzy if you worship Godzamok and prevent rapid buy/sell spam
+      //Automatically sell all cursors and farms (except one) during Dragonflight and Click Frenzy if you worship Godzamok and prevent rapid buy/sell spam
       if (
         FrozenCookies.autoGodzamok >= 1 &&
         hasClickBuff() &&
         !Game.hasBuff("Devastation")
       ) {
+        Game.Objects["Cursor"].sell(countCursor);
         Game.Objects["Farm"].sell(countFarm);
-        Game.Objects["Mine"].sell(countMine);
-        Game.Objects["Factory"].sell(countFactory);
 
         if (FrozenCookies.autoBuy == 1) {
+          safeBuy(Game.Objects["Cursor"], countCursor);
+          logEvent("AutoGodzamok", "Bought " + countCursor + " cursors");
           safeBuy(Game.Objects["Farm"], countFarm);
           logEvent("AutoGodzamok", "Bought " + countFarm + " farms");
-          safeBuy(Game.Objects["Mine"], countMine);
-          logEvent("AutoGodzamok", "Bought " + countMine + " mines");
-          safeBuy(Game.Objects["Factory"], countFactory);
-          logEvent("AutoGodzamok", "Bought " + countFactory + " factories");
         }
       }
     }


### PR DESCRIPTION
Changed to cursors and farms as per documention.

In the current version devastation is seling factories and mines so this stops being useful after you own over 600 of the latter, leading to a net cookie loss every time you get a click frenzy or dragon flight.